### PR TITLE
Fixed description not returning attribute class & able to set css classes to label and column div for eav form type.

### DIFF
--- a/Model/Attribute.php
+++ b/Model/Attribute.php
@@ -176,10 +176,14 @@ class Attribute implements AttributeInterface
      * Set Description
      *
      * @param string $description
+     *
+     * @return Attribute
      */
     public function setDescription($description)
     {
         $this->description = $description;
+
+        return $this;
     }
 
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -3,8 +3,8 @@
 {% block eav_value_row %}
     {% spaceless %}
         <div class="form-group {% if form.vars.attribute.valueType == 'nested' %}form-group-nested-content{% endif %}">
-            {{ form_label(form) }}
-            <div class="col-lg-10">
+            <label class="{{ form.vars.attr.label_class|default('control-label col-lg-2 required') }}">{{ form.vars.label }}</label>
+            <div class="{{ form.vars.attr.column_class|default('col-lg-10') }}">
                 {% for child in form.children %}
                     {{ form_widget(child, {'attr': attr}) }}
                 {% endfor %}


### PR DESCRIPTION
- Fixed description not returning attribute class
- Able to set css classes to label and column div for eav form type.